### PR TITLE
Update all packages because the official Docker images lags behind in security fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM centos:7
 
-RUN yum -y install http://pkg.inclusivedesign.ca/centos/7/x86_64/Packages/idi-release-1.0-0.noarch.rpm && \
+RUN yum -y update && \
+    yum -y install http://pkg.inclusivedesign.ca/centos/7/x86_64/Packages/idi-release-1.0-0.noarch.rpm && \
     rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-IDI && \
     yum -y install epel-release && \
     yum -y install ansible git sudo supervisor && \

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,7 @@
+[supervisord]
+nodaemon=true
+logfile=/dev/null
+pidfile=/var/run/supervisord.pid
+
+[include]
+files = supervisord.d/*.ini

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,7 +1,0 @@
-[supervisord]
-nodaemon=true
-logfile=/dev/null
-pidfile=/var/run/supervisord.pid
-
-[include]
-files = supervisord.d/*.ini


### PR DESCRIPTION
Due to Docker Security Scanning, today we (I?) learned that the official images of all major distributions are plagued with security vulnerabilities. Most of them have been already patched upstream but the Docker images have not been updated in a timely fashion.

Evidence:

    $ docker pull centos
    Using default tag: latest
    Trying to pull repository docker.io/library/centos ... 
    latest: Pulling from docker.io/library/centos
    a3ed95caeb02: Already exists 
    5989106db7fb: Already exists 
    Digest: sha256:1b9adf413b3ab95ce430c2039954bb0db0c8e2672c48182f2c5b3d30373d5b71
    Status: Image is up to date for docker.io/centos:latest
    
    $ docker run --rm -ti centos yum check-updates
    Loaded plugins: fastestmirror, ovl
    base                                                 | 3.6 kB     00:00     
    extras                                               | 3.4 kB     00:00     
    updates                                              | 3.4 kB     00:00     
    (1/4): extras/7/x86_64/primary_db                      | 117 kB   00:00     
    (2/4): base/7/x86_64/group_gz                          | 155 kB   00:00     
    (3/4): base/7/x86_64/primary_db                        | 5.3 MB   00:05     
    (4/4): updates/7/x86_64/primary_db                     | 4.1 MB   00:06     
    Determining fastest mirrors
     * base: centos.xpg.com.br
     * extras: centos.xpg.com.br
     * updates: centos.xpg.com.br
    
    kpartx.x86_64                        0.4.9-85.el7_2.1                updates
    krb5-libs.x86_64                     1.13.2-12.el7_2                 updates
    libblkid.x86_64                      2.23.2-26.el7_2.2               updates
    libmount.x86_64                      2.23.2-26.el7_2.2               updates
    libuuid.x86_64                       2.23.2-26.el7_2.2               updates
    nspr.x86_64                          4.11.0-1.el7_2                  updates
    nss.x86_64                           3.21.0-9.el7_2                  updates
    nss-softokn.x86_64                   3.16.2.3-14.2.el7_2             updates
    nss-softokn-freebl.x86_64            3.16.2.3-14.2.el7_2             updates
    nss-sysinit.x86_64                   3.21.0-9.el7_2                  updates
    nss-tools.x86_64                     3.21.0-9.el7_2                  updates
    nss-util.x86_64                      3.21.0-2.2.el7_2                updates
    openldap.x86_64                      2.4.40-9.el7_2                  updates
    openssl-libs.x86_64                  1:1.0.1e-51.el7_2.5             updates
    systemd.x86_64                       219-19.el7_2.7                  updates
    systemd-libs.x86_64                  219-19.el7_2.7                  updates
    tzdata.noarch                        2016d-1.el7                     updates
    util-linux.x86_64                    2.23.2-26.el7_2.2               updates

Which translates into this report:

![docker-centos-official-image-vulnerabilities](https://cloud.githubusercontent.com/assets/5902830/15198432/abaa2fbe-17ad-11e6-8395-6ab03189426a.png)

While discussing thi